### PR TITLE
Add internal health checks for DB and Redis on startup and also

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,7 @@
     "build": "tsc -b && vite build",
     "lint": "eslint .",
     "preview": "vite preview --host 0.0.0.0 --port 3000",
-    "test": "npx playwright test"
+    "test": "npx playwright test && npx playwright show-report"
   },
   "engines": {
     "node": ">=22"

--- a/server/src/api/controllers/on_startup.py
+++ b/server/src/api/controllers/on_startup.py
@@ -1,10 +1,10 @@
 import os
 import asyncio
-import redis.asyncio as redis
 from fastapi import APIRouter
 from alembic import command
 from alembic.config import Config
 from src.db.db_check import check_database_connection
+from src.api.controllers.health_check import check_redis_connection
 
 router = APIRouter()
 
@@ -16,22 +16,6 @@ async def run_migration():
     except Exception as e:
         print(f"Error during migration: {e}")
         raise
-
-
-async def check_redis_connection():
-    redis_url = os.getenv("REDIS_URL")
-    client = redis.from_url(redis_url)
-    try:
-        pong = await client.ping()
-        if pong:
-            print("Redis connection OK")
-        else:
-            raise ConnectionError("Redis ping failed")
-    except Exception as e:
-        print(f"Redis connection failed: {e}")
-        raise
-    finally:
-        await client.close()
 
 @router.on_event("startup")
 async def on_startup():

--- a/server/src/core/config.py
+++ b/server/src/core/config.py
@@ -17,6 +17,8 @@ class Settings:
     SECRET_KEY: str = os.getenv("SECRET_KEY", "default-secret-key")
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 30
+    REDIS_URL: str = os.getenv("REDIS_URL")
+    CELERY_BROKER_URL: str = os.getenv("CELERY_BROKER_URL")
     MINIO_ENDPOINT: str = os.getenv("MINIO_ENDPOINT", "localhost:9000")
     MINIO_ROOT_USER: str = os.getenv("MINIO_ROOT_USER", "minio-admin")
     MINIO_ROOT_PASSWORD: str = os.getenv("MINIO_ROOT_PASSWORD", "minio-secret-key")

--- a/server/src/worker.py
+++ b/server/src/worker.py
@@ -1,7 +1,7 @@
-import os
 from celery import Celery
+from src.core.config import settings
 
-broker_url = os.getenv("CELERY_BROKER_URL")
+broker_url = settings.CELERY_BROKER_URL
 
 celery_app = Celery(
     "worker",


### PR DESCRIPTION
including Celery in /api/v1/health route

I added health checks and refactored the code slightly to centralize health check features in health_check.py. Should we create Redis and Celery check files? The database connection has its own file in db/db_check.py. We could, for example, create a health check folder where we add all the health checks so they are not bound to health_check.py, since it's a route file. If we create the folder where it should be located?