### PR TITLE
Remove celery volume mount in dev docker since it will overwrite .venv

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -54,7 +54,7 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 RUN addgroup -S celerygroup && adduser -S celeryuser -G celerygroup
 
 WORKDIR /app
-COPY --from=server-builder --chown=celeryuser:celeryuser /app/.venv /app/.venv
+COPY --from=server-builder --chown=celeryuser:celerygroup /app/.venv /app/.venv
 
 COPY server/. /app
 RUN chown -R celeryuser:celerygroup /app

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -82,11 +82,11 @@ services:
       - ./postgres-init-scripts:/docker-entrypoint-initdb.d
 
   adminer:
-      container_name: adminer_${APP_ENV:-dev}
-      image: adminer:5.3.0@sha256:6bc678e77abcd8c7f34133f4903a4be485ec38b17df3d40a845ee56af0fcb32a
-      restart: always
-      ports:
-        - ${ADMINER_PORT:-8080}:8080
+    container_name: adminer_${APP_ENV:-dev}
+    image: adminer:5.3.0@sha256:6bc678e77abcd8c7f34133f4903a4be485ec38b17df3d40a845ee56af0fcb32a
+    restart: always
+    ports:
+      - ${ADMINER_PORT:-8080}:8080
 
   minio:
     image: minio/minio:latest@sha256:064117214caceaa8d8a90ef7caa58f2b2aeb316b5156afe9ee8da5b4d83e12c8
@@ -110,7 +110,7 @@ services:
     image: redis:7.4.5-alpine@sha256:0c0142c3cd69bc030ea09fecfa1c1c0c7d0e7d6081be6bb4957804f23d2cf57a
     container_name: redis_${APP_ENV:-dev}
     privileged: true
-    volumes: 
+    volumes:
       - redis_data:/data
 
   celery:
@@ -133,8 +133,6 @@ services:
       MINIO_ROOT_PASSWORD: minio-secret-key
     depends_on:
       - redis
-    volumes:
-      - ./server:/app
 
   flower:
     container_name: flower_${APP_ENV:-dev}


### PR DESCRIPTION
**Quick fix**

`./server:/app` volume mount seemed to overwrite the `.venv` created in `Dockerfile-dev`, which would crash celery. Removing the volume fixed the crashing.

It probably was there to begin with to allow hot reloading? Hot reloading should probably be done similarly as with backend using `watch`.