### PR TITLE
Specify ports and update architecture diagram

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,14 @@
-localhost {
+{
+	http_port  9080
+	https_port 9443
+	auto_https disable_redirects
+}
+
+localhost:9080 {
+    redir https://localhost:3000{uri} permanent
+}
+
+localhost:9443 {
 	tls internal
 
 	handle /api* {

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,6 @@ FROM caddy:2.10.0-alpine@sha256:ae4458638da8e1a91aafffb231c5f8778e964bca650c8a8c
 COPY Caddyfile /etc/caddy/Caddyfile
 COPY --from=client-build /app/dist /srv
 
-EXPOSE 443
-
 FROM python:3.14-alpine AS server-builder
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 

--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ The startup of the app may a while due to the download of corresponding Docker i
 
 After startup, open the application:
 
-If you ran `start-prod`, navigate to [https://localhost](https://localhost) (the Caddy server's root CA is by default untrusted. You can bypass the browser warning). 
+If you ran `start-prod`, navigate to [https://localhost:3000](https://localhost:3000) (the Caddy server's root CA is by default untrusted. You can bypass the browser warning).
 
-If you used `make start-dev`, navigate to [http://localhost:3000](http://localhost:3000)
+If you used `make start-dev`, navigate to [http://localhost:3001](http://localhost:3001)
 
 
 #### Windows (non-WSL)
@@ -127,13 +127,13 @@ Python, FastAPI, PostgreSQL, SQLAlchemy, Alembic
 
 ### Getting started with development
 
-Open up the client: [http://localhost:3000](http://localhost:3000)
+Open up the client: [http://localhost:3001](http://localhost:3001)
 
-`/api` is proxied to the backend container, e.g. `http://localhost:3000/api/v1/health` will be proxied to `http://localhost:8080/api/v1/health`.
+`/api` is internally proxied to the backend container, e.g. `http://localhost:3001/api/v1/health` will be proxied to `http://localhost:8080/api/v1/health`.
 
-API docs: [http://localhost:3000/documentation](http://localhost:3000/docs)
+API: [http://localhost:3001/api/v1](http://localhost:3001/api/v1)
 
-Server: [http://localhost:8080](http://localhost:3000)
+API docs: [http://localhost:3001/documentation](http://localhost:3001/docs)
 
 Adminer GUI: [http://localhost:8081/?pgsql=postgres&username=your_username&db=your_database_dev&ns=](http://localhost:8081/?pgsql=postgres&username=your_username&db=your_database_dev&ns=) password: **your_password**
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The tool has been tested with CSV data exported from [Scopus](https://www.scopus
 
 ### LLMs Access
 The application is integrated with [OpenRouter](https://openrouter.ai/), which supports multiple LLMs ranging from very affordable to top-tier models like OpenAI’s ChatGPT, Google’s Gemini, Anthropic’s Claude, Meta's LLama, and Mistral. To use the models, you need to provide an [OpenRouter](https://openrouter.ai/) key. You can set spending limits for each key directly on the [OpenRouter](https://openrouter.ai/) website. New users also receive $5 in free credits when creating an account.
+
 <img width="784" height="117" alt="{585DBE92-5A2F-412E-BEF1-A727015EE872}" src="https://github.com/user-attachments/assets/bc112d74-31a0-4ce0-aeec-4879030c391e" />
 
 ### LLM screening speed
@@ -108,6 +109,10 @@ TypeScript, React, Tailwind CSS, Vite, Wouter, Zod, Redux
 ### Back-end
 
 Python, FastAPI, PostgreSQL, SQLAlchemy, Alembic
+
+### System design
+
+See [Architecture.md](docs/Architecture.md)
 
 ## Development requirements
 - Node.js v22 LTS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       dockerfile: Dockerfile
       target: client
     ports:
-      - "127.0.0.1:443:443"
-      - "127.0.0.1:80:80"
+      - "127.0.0.1:3000:9443"
+      - "127.0.0.1:3080:9080"
     volumes:
       - caddy_data:/data
       - caddy_config:/config
@@ -22,7 +22,7 @@ services:
       context: .
       dockerfile: Dockerfile
       target: server
-    ports: ["127.0.0.1:5678:5678"]
+    ports: ["127.0.0.1:5678:5678"] # Debug port
     environment:
       PYTHONPATH: /app
       APP_ENV: prod

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -31,8 +31,7 @@ graph TD
     Client -- "HTTPS :3000" --> Caddy
 
     Caddy -- "Serves" --> React
-    Client -- "/api/*" --> Caddy
-    Caddy -- "/api/*" --> FastAPI
+    Caddy -- "Proxies /api/*" --> FastAPI
 
     FastAPI --> Postgres
     FastAPI --> Redis

--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -1,3 +1,59 @@
 # Architecture
 
-![alt text](architecture.svg)
+```mermaid
+graph TD
+
+    Client["Client (Browser)"]
+
+    subgraph Proxy_Layer ["Frontend Container"]
+        Caddy
+        React["React App"]
+    end
+
+    subgraph Backend ["Backend Logic"]
+        FastAPI["FastAPI"]
+        Celery["Celery Worker"]
+    end
+
+    subgraph Data ["Data"]
+        Postgres[("PostgreSQL")]
+        Redis[("Redis (Broker/Cache)")]
+        MinIO[("MinIO (S3 Storage)")]
+    end
+
+    subgraph Tools
+        Flower
+        Adminer
+    end
+
+    Client -- "HTTP :8080" --> Adminer
+    Client -- "HTTP :5555" --> Flower
+    Client -- "HTTPS :3000" --> Caddy
+
+    Caddy -- "Serves" --> React
+    Client -- "/api/*" --> Caddy
+    Caddy -- "/api/*" --> FastAPI
+
+    FastAPI --> Postgres
+    FastAPI --> Redis
+    FastAPI --> MinIO
+    Celery --> Redis
+    Celery --> Postgres
+```
+
+## Port Mapping
+
+| Service | Port | Container port|
+| --------------- | --------------- | --------------- |
+| Frontend (https) | 3000 | 9443 |
+| Frontend redir (http)| 3080 | 9080 |
+| Backend API | --- | 8080 |
+| Adminer | 8080  | 8080 |
+| Flower | 5555 | 5555|
+| MinIO API | 9000 | 9000|
+| MinIO Console | 9001 | 9001|
+| PostgreSQL | 5432| 5432|
+| Redis | 6379 | 6379 |
+
+
+

--- a/start-dev.bat
+++ b/start-dev.bat
@@ -1,6 +1,6 @@
-set FRONTEND_PORT=3000
-set FLOWER_PORT=5555
-set ADMINER_PORT=8080
+set FRONTEND_PORT=3001
+set FLOWER_PORT=5556
+set ADMINER_PORT=8081
 set APP_ENV=dev
 
 docker compose -f docker-compose.yml -p dev up --build


### PR DESCRIPTION
- Change the default production port to 3000
   -  HTTP at 3080 but redirected back to HTTPS 3000
- Update `start-dev.bat` ports to be consistent with regular ports
- Update README prod and dev links to correct ports 
- Update architecture diagram to better reflect prod
- Add port mappings (external and internal) to `Architecture.md`

Resolves #168 