### PR TITLE
Fix empty abstacts throwing error

### DIFF
--- a/server/src/tools/csv_file_validation.py
+++ b/server/src/tools/csv_file_validation.py
@@ -38,7 +38,7 @@ def validate_csv(
                 0,
             )
 
-        df = df.where(df.notna(), None)
+        df = df.astype(object).where(df.notna(), None)
         empty_abstract_count = df["abstract"].isna().sum()
 
         records = df.to_dict("records")


### PR DESCRIPTION
I don't know why this bug exists in the dev-branch, but for some reason the NaNs are not cast correctly to None.

I have no idea what change introduced this bug...