### PR TITLE
Fix tests that touch celery by cleaning up the db after the tests

### DIFF
--- a/server/conftest.py
+++ b/server/conftest.py
@@ -4,21 +4,18 @@ from io import BytesIO
 import pytest
 import pytest_asyncio
 from fastapi import UploadFile
+from sqlalchemy import text
 from starlette.datastructures import Headers
 
 from src.core.config import settings
 from src.crud.project_crud import ProjectCrud
+from src.crud.user_crud import UserCrud
 from src.db.db_context import DBContext
 from src.db.session import Base, engine
-from src.crud.user_crud import UserCrud
-from src.schemas.user import UserCreate
-from src.schemas.job import (
-    JobCreate,
-    LLMModelConfig,
-    ZeroShotPromptingConfig,
-)
+from src.schemas.job import JobCreate, LLMModelConfig, ZeroShotPromptingConfig
+from src.schemas.llm import Criterion, Decision, LikertDecision, StructuredResponse
 from src.schemas.project import Criteria, ProjectCreate
-from src.schemas.llm import StructuredResponse, Criterion, Decision, LikertDecision
+from src.schemas.user import UserCreate
 from src.tools.diagnostics.db_check import run_migration
 
 # @pytest.fixture(scope="function")
@@ -26,13 +23,17 @@ from src.tools.diagnostics.db_check import run_migration
 #     with TestClient(app) as client:
 #         yield client
 
+PROTECTED_TABLES = {"alembic_version"}
+
 
 @pytest_asyncio.fixture
 async def test_user_uuid(db_ctx):
     user_crud = db_ctx.crud(UserCrud)
     user = await user_crud.get_user_by_sub("test-user")
     if not user:
-        user = await user_crud.create_user(UserCreate(sub="test-user", email="test@test.com"))
+        user = await user_crud.create_user(
+            UserCreate(sub="test-user", email="test@test.com")
+        )
         await db_ctx.commit()
     return user.uuid
 
@@ -164,8 +165,30 @@ async def db_ctx():
         await ctx.rollback()
 
 
+@pytest_asyncio.fixture
+async def committing_db():
+    await _truncate_all()
+    yield
+    await _truncate_all()
+
+
 @pytest_asyncio.fixture(autouse=True)
 async def reset_shared_redis():
     yield
     from src.redis_client.client import close_shared_redis_client
+
     await close_shared_redis_client()
+
+
+async def _truncate_all():
+    tables = [
+        f'"{t.name}"'
+        for t in Base.metadata.sorted_tables
+        if t.name not in PROTECTED_TABLES
+    ]
+    if not tables:
+        return
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(f"TRUNCATE {', '.join(tables)} RESTART IDENTITY CASCADE")
+        )

--- a/server/conftest.py
+++ b/server/conftest.py
@@ -23,8 +23,6 @@ from src.tools.diagnostics.db_check import run_migration
 #     with TestClient(app) as client:
 #         yield client
 
-PROTECTED_TABLES = {"alembic_version"}
-
 
 @pytest_asyncio.fixture
 async def test_user_uuid(db_ctx):
@@ -181,11 +179,7 @@ async def reset_shared_redis():
 
 
 async def _truncate_all():
-    tables = [
-        f'"{t.name}"'
-        for t in Base.metadata.sorted_tables
-        if t.name not in PROTECTED_TABLES
-    ]
+    tables = [f'"{t.name}"' for t in Base.metadata.sorted_tables]
     if not tables:
         return
     async with engine.begin() as conn:

--- a/server/src/celery/tasks.py
+++ b/server/src/celery/tasks.py
@@ -8,11 +8,6 @@ from pydantic_ai.retries import AsyncTenacityTransport, RetryConfig, wait_retry_
 from tenacity import retry_if_exception_type, stop_after_attempt, wait_exponential
 
 from celery import Task
-from src.tools.boolean_parser import (
-    build_criteria_tree_with_expressions,
-    compute_overall,
-    extract_leaf_criteria,
-)
 from src.crud.jobtask_crud import JobTaskCrud
 from src.crud.project_crud import ProjectCrud
 from src.db.db_context import DBContext
@@ -24,6 +19,11 @@ from src.schemas.jobtask import JobTaskStatus
 from src.schemas.project import Criteria
 from src.services.llm_service import create_llm_service
 from src.services.paper_service import create_paper_service
+from src.tools.boolean_parser import (
+    build_criteria_tree_with_expressions,
+    compute_overall,
+    extract_leaf_criteria,
+)
 from src.tools.llm_decision_creator import (
     get_single_criterion_response,
     get_structured_response,
@@ -48,7 +48,6 @@ def process_job_task(self: Task, job_id: int, job_data: dict):
     job_data_unpacked = JobCreate.model_validate(job_data, strict=True)
     logger.info("Running job task using asyncio, ID: %s", job_id)
     asyncio.run(process_job(self, job_id, job_data_unpacked))
-
 
 
 def _create_retrying_client(max_attempts: int = 3, max_wait_seconds=60) -> AsyncClient:
@@ -198,7 +197,13 @@ async def _process_standard_task(
                 logger.exception("Failed to publish error %s", job_task_id)
         finally:
             await _update_progress(
-                celery_task, redis, job_id, job_data.owner_uuid, counter, counter_lock, update_interval
+                celery_task,
+                redis,
+                job_id,
+                job_data.owner_uuid,
+                counter,
+                counter_lock,
+                update_interval,
             )
 
 
@@ -311,7 +316,13 @@ async def _process_per_criteria_task(
 
         finally:
             await _update_progress(
-                celery_task, redis, job_id, job_data.owner_uuid, counter, counter_lock, update_interval
+                celery_task,
+                redis,
+                job_id,
+                job_data.owner_uuid,
+                counter,
+                counter_lock,
+                update_interval,
             )
 
 
@@ -321,6 +332,7 @@ async def process_job(
     job_data: JobCreate,
     max_concurrent_tasks: int = 20,
     max_retries: int = 3,
+    update_interval: int = 5,
 ):
     logger.info("process_job: Starting to process job %s", job_id)
     redis = get_redis_client()
@@ -331,7 +343,9 @@ async def process_job(
         jobtask_crud = db_ctx.crud(JobTaskCrud)
 
         logger.info("Fetching project by UUID %s", job_data.project_uuid)
-        project = await project_crud.fetch_project_by_uuid(job_data.project_uuid, job_data.owner_uuid)
+        project = await project_crud.fetch_project_by_uuid(
+            job_data.project_uuid, job_data.owner_uuid
+        )
         if project is None:
             raise RuntimeError("Project not found")
 
@@ -373,6 +387,7 @@ async def process_job(
                 counter=counter,
                 counter_lock=counter_lock,
                 client=client,
+                update_interval=update_interval,
             )
             for jt_id in job_task_ids
         ]
@@ -389,6 +404,7 @@ async def process_job(
                 counter=counter,
                 counter_lock=counter_lock,
                 client=client,
+                update_interval=update_interval,
             )
             for jt_id in job_task_ids
         ]

--- a/server/src/tests/test_003_job.py
+++ b/server/src/tests/test_003_job.py
@@ -76,7 +76,6 @@ async def test_create_and_fetch_job_crud(db_ctx):
     assert fetched_job is not None
     assert job is not None
 
-    print(job.llm_config)
     # FIX: Does not currently return JobRead but raw data: should be fixed
     # assert isinstance(job, JobRead)
     assert job.project_uuid == job_data.project_uuid

--- a/server/src/tests/test_004_jobtask.py
+++ b/server/src/tests/test_004_jobtask.py
@@ -114,13 +114,10 @@ async def test_create_job_transaction_rollback(db_ctx, test_files_working, monke
     assert len(jobs) == 0
 
 
-# TODO: Run seperately or refactor test setup (and teardown) for tests that deal with task running.
-# The functions tested commit to db which leads to inconsistent db state for other tests.
 @pytest.mark.asyncio
 @patch("src.celery.tasks.get_structured_response", new_callable=AsyncMock)
-@pytest.mark.skip(reason="Should be moved to somewhere else since commits to db")
 async def test_async_process_job(
-    mock_get_structured_response, test_job_data, test_structured_response
+    mock_get_structured_response, committing_db, test_job_data, test_structured_response
 ):
     async with DBContext() as db_ctx:
         job_crud = db_ctx.crud(JobCrud)
@@ -172,7 +169,7 @@ async def test_async_process_job(
     celery_task = MagicMock()
     celery_task.update_state = MagicMock()
 
-    await process_job(celery_task, job.id, test_job_data)
+    await process_job(celery_task, job.id, test_job_data, update_interval=1)
 
     calls = celery_task.update_state.call_args_list
     progress_calls = [c for c in calls if c[1].get("state") == "PROGRESS"]
@@ -188,10 +185,9 @@ async def test_async_process_job(
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(reason="Should be moved to somewhere else since commits to db")
 @patch("src.celery.tasks.get_structured_response", new_callable=AsyncMock)
 async def test_async_process_job_failure(
-    mock_get_structured_response, test_job_data, test_structured_response
+    mock_get_structured_response, committing_db,  test_job_data, test_structured_response
 ):
     async with DBContext() as db_ctx:
         job_crud = db_ctx.crud(JobCrud)
@@ -254,7 +250,7 @@ async def test_async_process_job_failure(
     mock_get_structured_response.side_effect = fail_on_second_call
 
     # Would retry task if max_retries=0 wasn't set
-    await process_job(celery_task, job.id, test_job_data, max_retries=0)
+    await process_job(celery_task, job.id, test_job_data, max_retries=0, update_interval=1)
 
     calls = celery_task.update_state.call_args_list
     progress_calls = [c for c in calls if c[1].get("state") == "PROGRESS"]

--- a/server/src/tests/test_004_jobtask.py
+++ b/server/src/tests/test_004_jobtask.py
@@ -261,8 +261,6 @@ async def test_async_process_job_failure(
         jobtask_crud = db_ctx.crud(JobTaskCrud)
         tasks = await jobtask_crud.fetch_job_tasks_by_job_id(job.id)
 
-        print(tasks[0].error)
-        print(tasks[1].error)
         done_count = sum(1 for t in tasks if t.status.value == JobTaskStatus.DONE.value)
         error_count = sum(
             1 for t in tasks if t.status.value == JobTaskStatus.ERROR.value

--- a/server/src/tests/test_006_auth.py
+++ b/server/src/tests/test_006_auth.py
@@ -3,8 +3,8 @@ import uuid
 
 import pytest
 from fastapi import HTTPException
-from starlette.requests import Request
 from starlette.datastructures import Headers
+from starlette.requests import Request
 
 from src.core.auth import get_current_user
 from src.core.config import settings
@@ -40,9 +40,11 @@ async def test_unauthenticated_request(db_ctx):
 @pytest.mark.asyncio
 async def test_invalid_session(db_ctx):
     session_id = str(uuid.uuid4())
-    session_data = json.dumps({
-        "user_uuid": str(uuid.uuid4()),
-    })
+    session_data = json.dumps(
+        {
+            "user_uuid": str(uuid.uuid4()),
+        }
+    )
     redis_client = get_redis_client()
     await redis_client.setex(
         f"session:{session_id}",
@@ -58,13 +60,16 @@ async def test_invalid_session(db_ctx):
 @pytest.mark.asyncio
 async def test_valid_session_returns_user(db_ctx):
     user_crud = db_ctx.crud(UserCrud)
-    user = await user_crud.create_user(UserCreate(sub="session-test-user", email="s@test.com"))
-    await db_ctx.commit()
+    user = await user_crud.create_user(
+        UserCreate(sub="session-test-user", email="s@test.com")
+    )
 
     session_id = str(uuid.uuid4())
-    session_data = json.dumps({
-        "user_uuid": str(user.uuid),
-    })
+    session_data = json.dumps(
+        {
+            "user_uuid": str(user.uuid),
+        }
+    )
     redis_client = get_redis_client()
     await redis_client.setex(
         f"session:{session_id}",
@@ -80,8 +85,9 @@ async def test_valid_session_returns_user(db_ctx):
 async def test_create_user_with_consent(db_ctx):
     service = create_user_service(db_ctx)
     consent = ConsentAccept(terms=True, privacy_policy=True, research=True)
-    user = await service.create_user_with_consent(sub="new-user", email="new@test.com", consent=consent)
-    await db_ctx.commit()
+    user = await service.create_user_with_consent(
+        sub="new-user", email="new@test.com", consent=consent
+    )
 
     assert isinstance(user, UserRead)
     assert user.sub == "new-user"
@@ -93,8 +99,9 @@ async def test_create_user_with_consent(db_ctx):
 async def test_create_user_with_consent_research_optional(db_ctx):
     service = create_user_service(db_ctx)
     consent = ConsentAccept(terms=True, privacy_policy=True, research=None)
-    user = await service.create_user_with_consent(sub="no-research-user", email="nr@test.com", consent=consent)
-    await db_ctx.commit()
+    user = await service.create_user_with_consent(
+        sub="no-research-user", email="nr@test.com", consent=consent
+    )
 
     assert user.consent_anonymized_research_usage is None
 
@@ -108,18 +115,22 @@ async def test_users_only_see_their_own_projects(db_ctx):
     user_b = await user_crud.create_user(UserCreate(sub="user-b", email="b@test.com"))
 
     for i in range(1, 4):
-        await project_crud.create_project(ProjectCreate(
-            name=f"User A Project {i}",
-            owner_uuid=user_a.uuid,
-            criteria=Criteria(inclusion_criteria=["A"], exclusion_criteria=["B"]),
-        ))
+        await project_crud.create_project(
+            ProjectCreate(
+                name=f"User A Project {i}",
+                owner_uuid=user_a.uuid,
+                criteria=Criteria(inclusion_criteria=["A"], exclusion_criteria=["B"]),
+            )
+        )
 
     for i in range(1, 3):
-        await project_crud.create_project(ProjectCreate(
-            name=f"User B Project {i}",
-            owner_uuid=user_b.uuid,
-            criteria=Criteria(inclusion_criteria=["A"], exclusion_criteria=["B"]),
-        ))
+        await project_crud.create_project(
+            ProjectCreate(
+                name=f"User B Project {i}",
+                owner_uuid=user_b.uuid,
+                criteria=Criteria(inclusion_criteria=["A"], exclusion_criteria=["B"]),
+            )
+        )
 
     projects_a = await project_crud.fetch_projects(user_a.uuid)
     projects_b = await project_crud.fetch_projects(user_b.uuid)

--- a/server/src/tests/test_007_api.py
+++ b/server/src/tests/test_007_api.py
@@ -2,8 +2,8 @@ import pytest
 
 from src.crud.setting_crud import SettingCrud
 from src.crud.user_crud import UserCrud
-from src.schemas.user import UserCreate
 from src.schemas.setting import SettingCreate
+from src.schemas.user import UserCreate
 
 
 @pytest.mark.asyncio
@@ -14,20 +14,22 @@ async def test_users_only_see_their_own_api_keys(db_ctx):
     user_a = await user_crud.create_user(UserCreate(sub="user-a", email="a@test.com"))
     user_b = await user_crud.create_user(UserCreate(sub="user-b", email="b@test.com"))
 
-    await setting_crud.upsert_setting(SettingCreate(
-        owner_uuid=user_a.uuid,
-        name="openai_api_key",
-        value="api_key_a",
-        secret=True,
-    ))
-    await db_ctx.commit()
+    await setting_crud.upsert_setting(
+        SettingCreate(
+            owner_uuid=user_a.uuid,
+            name="openai_api_key",
+            value="api_key_a",
+            secret=True,
+        )
+    )
 
-    result_a = await setting_crud.fetch_setting("openai_api_key", owner_uuid=user_a.uuid)
+    result_a = await setting_crud.fetch_setting(
+        "openai_api_key", owner_uuid=user_a.uuid
+    )
     assert result_a.value == "api_key_a"
 
     cross = await setting_crud.fetch_setting("openai_api_key", owner_uuid=user_b.uuid)
     assert cross is None
-    
 
 
 @pytest.mark.asyncio
@@ -35,21 +37,30 @@ async def test_users_can_only_delete_their_own_api_keys(db_ctx):
     user_crud = db_ctx.crud(UserCrud)
     setting_crud = db_ctx.crud(SettingCrud)
 
-    user_a = await user_crud.create_user(UserCreate(sub="del-user-a", email="da@test.com"))
-    user_b = await user_crud.create_user(UserCreate(sub="del-user-b", email="db@test.com"))
+    user_a = await user_crud.create_user(
+        UserCreate(sub="del-user-a", email="da@test.com")
+    )
+    user_b = await user_crud.create_user(
+        UserCreate(sub="del-user-b", email="db@test.com")
+    )
 
-    await setting_crud.upsert_setting(SettingCreate(
-        owner_uuid=user_a.uuid,
-        name="openai_api_key",
-        value="api_key_a",
-        secret=True,
-    ))
-    await db_ctx.commit()
+    await setting_crud.upsert_setting(
+        SettingCreate(
+            owner_uuid=user_a.uuid,
+            name="openai_api_key",
+            value="api_key_a",
+            secret=True,
+        )
+    )
 
-    delete_result = await setting_crud.delete_setting("openai_api_key", owner_uuid=user_b.uuid)
+    delete_result = await setting_crud.delete_setting(
+        "openai_api_key", owner_uuid=user_b.uuid
+    )
     assert delete_result is False
 
-    result_a = await setting_crud.fetch_setting("openai_api_key", owner_uuid=user_a.uuid)
+    result_a = await setting_crud.fetch_setting(
+        "openai_api_key", owner_uuid=user_a.uuid
+    )
     assert result_a.value == "api_key_a"
 
 
@@ -58,25 +69,36 @@ async def tests_same_api_key_name_different_users(db_ctx):
     user_crud = db_ctx.crud(UserCrud)
     setting_crud = db_ctx.crud(SettingCrud)
 
-    user_a = await user_crud.create_user(UserCreate(sub="same-name-user-a", email="a@test.com"))
-    user_b = await user_crud.create_user(UserCreate(sub="same-name-user-b", email="b@test.com"))
+    user_a = await user_crud.create_user(
+        UserCreate(sub="same-name-user-a", email="a@test.com")
+    )
+    user_b = await user_crud.create_user(
+        UserCreate(sub="same-name-user-b", email="b@test.com")
+    )
 
-    await setting_crud.upsert_setting(SettingCreate(
-        owner_uuid=user_a.uuid,
-        name="openai_api_key",
-        value="api_key_a",
-        secret=True,
-    ))
-    await setting_crud.upsert_setting(SettingCreate(
-        owner_uuid=user_b.uuid,
-        name="openai_api_key",
-        value="api_key_b",
-        secret=True,
-    ))
-    await db_ctx.commit()
+    await setting_crud.upsert_setting(
+        SettingCreate(
+            owner_uuid=user_a.uuid,
+            name="openai_api_key",
+            value="api_key_a",
+            secret=True,
+        )
+    )
+    await setting_crud.upsert_setting(
+        SettingCreate(
+            owner_uuid=user_b.uuid,
+            name="openai_api_key",
+            value="api_key_b",
+            secret=True,
+        )
+    )
 
-    result_a = await setting_crud.fetch_setting("openai_api_key", owner_uuid=user_a.uuid)
+    result_a = await setting_crud.fetch_setting(
+        "openai_api_key", owner_uuid=user_a.uuid
+    )
     assert result_a.value == "api_key_a"
 
-    result_b = await setting_crud.fetch_setting("openai_api_key", owner_uuid=user_b.uuid)
+    result_b = await setting_crud.fetch_setting(
+        "openai_api_key", owner_uuid=user_b.uuid
+    )
     assert result_b.value == "api_key_b"


### PR DESCRIPTION
- committing_db() fixture can now be used if tests internally commit to the db
- Remove some unneccessary commits from auth and api tests
- Fixtures test_user_uuid() and test_project_uuid() still commit to the db, which might be something to change if needed

Resolves #147 